### PR TITLE
skip installing python-nautilus if it is already installed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -35,7 +35,7 @@ rm -f ~/.local/share/nautilus-python/extensions/code-nautilus.py
 
 # Download and install the extension
 echo "Downloading newest version..."
-wget --show-progress -O ~/.local/share/nautilus-python/extensions/code-nautilus.py https://raw.githubusercontent.com/cra0zy/code-nautilus/master/code-nautilus.py
+wget --show-progress -q -O ~/.local/share/nautilus-python/extensions/code-nautilus.py https://raw.githubusercontent.com/cra0zy/code-nautilus/master/code-nautilus.py
 
 # Restart nautilus
 echo "Restarting nautilus..."

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ then
     sudo pacman -S --noconfirm python-nautilus
 elif type "apt-get" > /dev/null 2>&1
 then
-    installed=`apt list --installed 2> /dev/null | grep python-nautilus`
+    installed=`apt list --installed python-nautilus -qq 2> /dev/null`
     if [ -z "$installed" ]
     then
         sudo apt-get install -y python-nautilus
@@ -16,7 +16,7 @@ then
     fi
 elif type "dnf" > /dev/null 2>&1
 then
-    installed=`dnf list installed 2> /dev/null | grep nautilus-python`
+    installed=`dnf list --installed nautilus-python 2> /dev/null`
     if [ -z "$installed" ]
     then
         sudo dnf install -y nautilus-python

--- a/install.sh
+++ b/install.sh
@@ -7,10 +7,22 @@ then
     sudo pacman -S --noconfirm python-nautilus
 elif type "apt-get" > /dev/null 2>&1
 then
-    sudo apt-get install -y python-nautilus
+    installed=`apt list --installed 2> /dev/null | grep python-nautilus`
+    if [ -z "$installed" ]
+    then
+        sudo apt-get install -y python-nautilus
+    else
+        echo "python-nautilus is already installed."
+    fi
 elif type "dnf" > /dev/null 2>&1
 then
-    sudo dnf install -y nautilus-python
+    installed=`dnf list installed 2> /dev/null | grep nautilus-python`
+    if [ -z "$installed" ]
+    then
+        sudo dnf install -y nautilus-python
+    else
+        echo "nautilus-python is already installed."
+    fi
 else
     echo "Failed to find python-nautilus, please install it manually."
 fi


### PR DESCRIPTION
Updating code-nautilus makes `dnf` and `apt` to check all repositories. This takes time and traffic (50Mb or more in some cases).  
